### PR TITLE
fix bug in normal-form double oracle and allow BR lists of size 1

### DIFF
--- a/open_spiel/python/algorithms/psro_oracle.py
+++ b/open_spiel/python/algorithms/psro_oracle.py
@@ -311,7 +311,6 @@ class PSRO(object):
                 br_policies.append(br_policy)
                 br_policies_probs.append(probs[i])
                 br_indices.append(available_brs[player][i])
-
         assert len(br_policies_probs) == len(br_policies)
 
         norm_br_policies_probs = [float(i) / sum(br_policies_probs) for i in br_policies_probs]
@@ -331,8 +330,8 @@ class PSRO(object):
 
         # update policy for children
         # just need new available brs which only change for current player
-        new_available_brs_for_player = []
         for action in legal_actions:
+            new_available_brs_for_player = []
             for i in range(len(br_policies)):
                 br_policy = br_policies[i]
                 if br_policy[action] == 1:
@@ -367,5 +366,5 @@ class PSRO(object):
             pyspiel.create_matrix_game(emperical_game_matrix, -emperical_game_matrix))
         norm_pos1 = abs(nash_prob_1) / sum(abs(nash_prob_1))
         norm_pos2 = abs(nash_prob_2) / sum(abs(nash_prob_2))
-        self._br_list[1] = np.squeeze(array(norm_pos1)).tolist()
-        self._br_list[3] = np.squeeze(array(norm_pos2)).tolist()
+        self._br_list[1] = np.squeeze(array(norm_pos1), axis=1).tolist()
+        self._br_list[3] = np.squeeze(array(norm_pos2), axis=1).tolist()


### PR DESCRIPTION
1. Allow populations of size 1 in `PSRO`
2. Fix bug where the policy from `PSRO._update_policy` would still think put BRs in `new_available_brs` if that BR was available for an *earlier* action, not the current action.

For example, in leduc, if there were 2 BRs, the first of which purely checks, and the second which purely bets, the update going down the `check` path would be correct, but the update going down the `bet` path would assume that both BRs were available, when really only the second should be available.

Found the bug by comparing exploitability of `PSRO._current_policy` with the policy from `open_spiel.python.algorithms.PolicyAggregator.aggregate()` and noticing that they were sometimes different:
```
    policy = policy_aggregator.PolicyAggregator(game).aggregate(
        [0,1],
        [[tabular_policy_from_callable(game, x) for x in solver._br_list[0]], [tabular_policy_from_callable(game, x) for x in solver._br_list[2]]],
        [solver._br_list[1], solver._br_list[3]])
```
and verified that after this fix, they were identical.