### PR TITLE
Fix 2 issues with BR_br_actions

### DIFF
--- a/open_spiel/python/algorithms/best_response.py
+++ b/open_spiel/python/algorithms/best_response.py
@@ -35,6 +35,12 @@ def _memoize_method(method):
 
   def wrap(self, arg):
     key = str(arg)
+    try:
+      # temporary hack/fix to make BRs work with games whose `str()` has imperfect recall (and/or is otherwise not a perfect representation of state)
+      # probably can revert back once the alternate BR mentioned in https://github.com/deepmind/open_spiel/issues/565#issuecomment-828570794 is in.
+      key = arg.history_str()
+    except Exception as e:
+      pass
     cache = vars(self).setdefault(cache_name, {})
     if key not in cache:
       cache[key] = method(self, arg)

--- a/open_spiel/python/algorithms/best_response_br_actions.py
+++ b/open_spiel/python/algorithms/best_response_br_actions.py
@@ -39,6 +39,8 @@ def _memoize_method(method):
     def wrap(self, arg):
         key = str(arg)
         try:
+            # temporary hack/fix to make BRs work with games whose `str()` has imperfect recall (and/or is otherwise not a perfect representation of state)
+            # probably can revert back once the alternate BR mentioned in https://github.com/deepmind/open_spiel/issues/565#issuecomment-828570794 is in.
             key = arg.history_str()
         except Exception as e:
             pass

--- a/open_spiel/python/algorithms/best_response_br_actions.py
+++ b/open_spiel/python/algorithms/best_response_br_actions.py
@@ -38,6 +38,10 @@ def _memoize_method(method):
 
     def wrap(self, arg):
         key = str(arg)
+        try:
+            key = arg.history_str()
+        except Exception as e:
+            pass
         cache = vars(self).setdefault(cache_name, {})
         if key not in cache:
             cache[key] = method(self, arg)
@@ -109,20 +113,11 @@ class BestResponsePolicy(pyspiel_policy.Policy):
             # hence return probability 1.0 for every action.
 
             br_policies = []
-            for br in self._br_list:
-                try:
-                    br_policy = _policy_dict_at_state(br[state.current_player()], state)
-                    # br_policy = br[state.current_player()][state]
-                    br_policies.append(br_policy)
-                except KeyError as err:
-                    # print(f"player: {state.current_player()} transitions key error: {err}")
-                    # if there is a key error that's because the BR didn't see that state so nothing is
-                    # initialized at that infoset so we can just have an arbitrary policy
-                    br_policy = {}
-                    for action in state.legal_actions(state.current_player()):
-                        br_policy[action] = 0
-                    br_policy[0] = 1
-                    br_policies.append(br_policy)
+            for brs in self._br_list:
+                br_policy = _policy_dict_at_state(brs[state.current_player()], state)
+                # br_policy = br[state.current_player()][state]
+                br_policies.append(br_policy)
+
             # br_policies = [_policy_dict_at_state(br[state.current_player()], state) for br in self._br_list]
             trans = []
             for action in state.legal_actions():
@@ -135,7 +130,19 @@ class BestResponsePolicy(pyspiel_policy.Policy):
         elif state.is_chance_node():
             return state.chance_outcomes()
         else:
-            return list(self._policy.action_probabilities(state).items())
+            br_policies = []
+            for brs in self._br_list:
+                br_policy = _policy_dict_at_state(brs[state.current_player()], state)
+                br_policies.append(br_policy)
+            trans = []
+            for action in state.legal_actions():
+                for br in br_policies:
+                    if br[action] == 1:
+                        trans.append(action)
+            trans = list(set(trans))
+            policy_action_probs = list(self._policy.action_probabilities(state).items())
+            assert all(a in trans or p==0 for a,p in policy_action_probs), f'policy_action_probs={policy_action_probs}, trans={trans}, state={state}, history={state.history_str()}'
+            return [(a,p) for a,p in policy_action_probs if a in trans]
 
     @_memoize_method
     def value(self, state):
@@ -219,4 +226,4 @@ class BestResponsePolicy(pyspiel_policy.Policy):
     """
         if player_id is None:
             player_id = state.current_player()
-        return {self.best_response_action(state.information_state_string(player_id), state): 1}
+        return {self.best_response_action(state): 1}


### PR DESCRIPTION
1. in `transitions()`, when traversing down the game tree, only traverse down actions within the br-restricted game, even for opponent actions.
2. in both normal BR and BR_br_actions, memoize by `history_str()` instead of `str`, for games where `str` has imperfect recall and/or is otherwise incomplete.  Maybe overkill, but solves our immediate problem.  In the long term, the fix mentioned in per https://github.com/deepmind/open_spiel/issues/565 should be more useful.

Also makes `action_probabilities` not error and removes a `try except` that I didn't find to be doing anything.  If either of these are intentionally in place, I can remove those changes from this PR.